### PR TITLE
get cursor position with binding in swiftui view

### DIFF
--- a/Sources/Views/FireflySyntaxView + TextDelegate.swift
+++ b/Sources/Views/FireflySyntaxView + TextDelegate.swift
@@ -151,6 +151,10 @@ extension FireflySyntaxView: UITextViewDelegate {
         return true
     }
     
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        updateCursorPosition()
+    }
+    
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         delegate?.didClickLink(URL.absoluteString)
         return false
@@ -169,9 +173,20 @@ extension FireflySyntaxView: UITextViewDelegate {
         return newLinePrefix
     }
     
-//    public func textViewDidChangeSelection(_ textView: UITextView) {
+    private func updateCursorPosition() {
+        if let cursorPositionChange = self.delegate?.cursorPositionChange {
+            if let pos = self.textView.cursorPosition() {
+                cursorPositionChange(self.textView.convert(pos, to: self.textView.superview))
+            } else {
+                cursorPositionChange(nil)
+            }
+        }
+    }
+    
+    public func textViewDidChangeSelection(_ textView: UITextView) {
+        updateCursorPosition()
 //        textStorage.updatePlaceholders(cursorRange: textView.selectedRange)
-//    }
+    }
 
     func updateSelectedRange(_ range: NSRange) {
         if range.location + range.length <= text.utf8.count {

--- a/Sources/Views/FireflyTextView.swift
+++ b/Sources/Views/FireflyTextView.swift
@@ -14,6 +14,19 @@ public class FireflyTextView: UITextView {
         }
     }
     
+    /// Returns a CGRect for the cursor position in the text view's coordinates. If no cursor is present, it returns nil.
+    /// source: https://stackoverflow.com/a/43167060/3902590
+    public func cursorPosition() -> CGRect? {
+        if let selectedRange = self.selectedTextRange
+        {
+            // `caretRect` is in the `textView` coordinate space.
+            return self.caretRect(for: selectedRange.end)
+        } else {
+            // No selection and no caret in UITextView.
+            return nil
+        }
+    }
+    
     public func currentWord() -> String {
         guard let cursorRange = self.selectedTextRange else { return "" }
         func getRange(from position: UITextPosition, offset: Int) -> UITextRange? {

--- a/Sources/Views/FireflyTextViewDelegate.swift
+++ b/Sources/Views/FireflyTextViewDelegate.swift
@@ -7,8 +7,10 @@
 //
 
 import Foundation
+import CoreGraphics
 
 public protocol FireflyDelegate: AnyObject {
+    var cursorPositionChange: ((_ cursorPosition: CGRect?) -> Void)? { get }
 
     func didChangeText(_ syntaxTextView: FireflyTextView)
 
@@ -22,6 +24,8 @@ public protocol FireflyDelegate: AnyObject {
 
 // Provide default empty implementations of methods that are optional.
 public extension FireflyDelegate {
+    var cursorPositionChange: ((_ cursorPosition: CGRect?) -> Void)? { nil }
+    
     func didChangeText(_ syntaxTextView: FireflyTextView) { }
 
     func didChangeSelectedRange(_ syntaxTextView: FireflyTextView, selectedRange: NSRange) { }

--- a/Sources/Views/Swift UI/FireflySyntaxViewSwift.swift
+++ b/Sources/Views/Swift UI/FireflySyntaxViewSwift.swift
@@ -15,6 +15,7 @@ import SwiftUI
 public struct FireflySyntaxEditor: UIViewRepresentable {
     
     @Binding var text: String
+    let cursorPosition: Binding<CGRect?>?
     
     var language: String
     var theme: String
@@ -24,8 +25,18 @@ public struct FireflySyntaxEditor: UIViewRepresentable {
     var didChangeSelectedRange: (FireflySyntaxEditor, NSRange) -> Void
     var textViewDidBeginEditing: (FireflySyntaxEditor) -> Void
 
-    public init(text: Binding<String>, language: String, theme: String, fontName: String, didChangeText: @escaping (FireflySyntaxEditor) -> Void, didChangeSelectedRange: @escaping (FireflySyntaxEditor, NSRange) -> Void, textViewDidBeginEditing: @escaping (FireflySyntaxEditor) -> Void) {
+    public init(
+        text: Binding<String>,
+        cursorPosition: Binding<CGRect?>? = nil,
+        language: String,
+        theme: String,
+        fontName: String,
+        didChangeText: @escaping (FireflySyntaxEditor) -> Void,
+        didChangeSelectedRange: @escaping (FireflySyntaxEditor, NSRange) -> Void,
+        textViewDidBeginEditing: @escaping (FireflySyntaxEditor) -> Void
+    ) {
         self._text = text
+        self.cursorPosition = cursorPosition
         self.didChangeText = didChangeText
         self.didChangeSelectedRange = didChangeSelectedRange
         self.textViewDidBeginEditing = textViewDidBeginEditing
@@ -51,8 +62,11 @@ public struct FireflySyntaxEditor: UIViewRepresentable {
     public func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
-    
+     
     public class Coordinator: FireflyDelegate {
+        
+        public var cursorPositionChange: ((CGRect?) -> Void)?
+        
         public func didClickLink(_ link: URL) { }
         
         let parent: FireflySyntaxEditor
@@ -60,6 +74,11 @@ public struct FireflySyntaxEditor: UIViewRepresentable {
         
         init(_ parent: FireflySyntaxEditor) {
             self.parent = parent
+            if let cursorPosition = parent.cursorPosition {
+                self.cursorPositionChange = {
+                    cursorPosition.wrappedValue = $0
+                }
+            }
         }
         
         public func didChangeText(_ syntaxTextView: FireflyTextView) {


### PR DESCRIPTION
Example usage

```swift
struct ContentView: View {
    @State var text = "hello"
    @State var cursorPosition: CGRect? = nil
    
    @ViewBuilder
    var autocompleteOverlay: some View {
        if let cursorPosition = cursorPosition {
            VStack {
                Text("You are typing here")
                Image(systemName: "arrow.down")
                    .foregroundColor(Color.red)
            }.offset(y: -20).position(x: cursorPosition.midX, y: cursorPosition.midY)
        }
    }
    
    var body: some View {
        ZStack {
            VStack {
                Text("firefly test")
                FireflySyntaxEditor(
                    text: $text,
                    cursorPosition: $cursorPosition,
                    language: "swift",
                    theme: "Xcode Light",
                    fontName: "system",
                    didChangeText: { _ in},
                    didChangeSelectedRange: {_,_ in},
                    textViewDidBeginEditing: {_ in}
                ).overlay(autocompleteOverlay)
            }
        }
    }
}
```