### PR TITLE
Fixes key commands modifiers matching on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Firefly",
     platforms: [
-        .iOS(SupportedPlatform.IOSVersion.v13)
+        .iOS(.v13),
+		.macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Tests/FireflyTests/FireflyTextViewTests.swift
+++ b/Tests/FireflyTests/FireflyTextViewTests.swift
@@ -1,0 +1,124 @@
+//
+//  FireflyTextViewTests.swift
+//
+//  Created by Marin Todorov on 11/7/21.
+//
+
+import XCTest
+@testable import Firefly
+
+class FireflyTextViewTests: XCTestCase {
+
+	private func keyDownEvent(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> NSEvent? {
+		return NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: modifiers, timestamp: Date().timeIntervalSinceReferenceDate, windowNumber: 0, context: nil, characters: "", charactersIgnoringModifiers: "", isARepeat: false, keyCode: keyCode)
+	}
+
+	func testKeyCommandModifiersMatching() throws {
+	#if canImport(AppKit)
+		let textView = FireflyTextView()
+
+		// Test keycommand with no modifier flags
+		var didTriggerCommand = false
+		textView.keyCommands = [.init(code: Keycode.tab, modifierFlags: [], action: {
+			didTriggerCommand = true
+			return true
+		})]
+
+		// No match for key
+		do {
+			didTriggerCommand = false
+
+			// Trigger tab key
+			let event = try XCTUnwrap(keyDownEvent(keyCode: Keycode.downArrow, modifiers: []))
+			textView.keyDown(with: event)
+
+			// Verify exectations
+			XCTAssertFalse(didTriggerCommand)
+		}
+
+		// Exact match for key
+		do {
+			didTriggerCommand = false
+
+			// Trigger tab key
+			let event = try XCTUnwrap(keyDownEvent(keyCode: Keycode.tab, modifiers: []))
+			textView.keyDown(with: event)
+
+			// Verify exectations
+			XCTAssertTrue(didTriggerCommand)
+		}
+
+		// Match with extra modifiers for key
+		do {
+			didTriggerCommand = false
+
+			// Trigger tab key + Shift
+			let event = try XCTUnwrap(keyDownEvent(keyCode: Keycode.tab, modifiers: [.shift]))
+			textView.keyDown(with: event)
+
+			// Verify exectations
+			XCTAssertTrue(didTriggerCommand)
+		}
+
+		// Exact match for key + modifiers
+		do {
+			didTriggerCommand = false
+
+			textView.keyCommands = [
+				.init(code: Keycode.tab, modifierFlags: [.shift, .control], action: {
+					didTriggerCommand = true
+					return true
+				})
+			]
+
+			// Trigger tab key + Shift + Control
+			let event = try XCTUnwrap(keyDownEvent(keyCode: Keycode.tab, modifiers: [.shift, .control]))
+			textView.keyDown(with: event)
+
+			// Verify exectations
+			XCTAssertTrue(didTriggerCommand)
+		}
+
+		// Match key + modifiers to an event with a superset of modifiers
+		do {
+			didTriggerCommand = false
+
+			textView.keyCommands = [
+				.init(code: Keycode.tab, modifierFlags: [.shift, .control], action: {
+					didTriggerCommand = true
+					return true
+				})
+			]
+
+			// Trigger tab key + Shift + Control
+			let event = try XCTUnwrap(keyDownEvent(keyCode: Keycode.tab, modifiers: [.shift, .control, .command, .capsLock]))
+			textView.keyDown(with: event)
+
+			// Verify exectations
+			XCTAssertTrue(didTriggerCommand)
+		}
+
+		// A match with higher precedence (more modifiers) blocks the one with less precedence
+		do {
+			didTriggerCommand = false
+
+			textView.keyCommands = [
+				.init(code: Keycode.tab, modifierFlags: [], action: {
+					didTriggerCommand = true
+					return true
+				}),
+				.init(code: Keycode.tab, modifierFlags: [.shift], action: {
+					return true
+				})
+			]
+
+			// Trigger tab key + Shift
+			let event = try XCTUnwrap(keyDownEvent(keyCode: Keycode.tab, modifiers: [.shift]))
+			textView.keyDown(with: event)
+
+			// Verify exectations
+			XCTAssertFalse(didTriggerCommand)
+		}
+	#endif
+    }
+}


### PR DESCRIPTION
`FireflyTextView.keyDown(with:)` uses `==` to compare event keyboard modifiers to the expected command modifiers. This approach doesn't yield the expected results  because the modifiers conform to `OptionSet` and therefore should be handled with Set algebra.

As per the documentation https://developer.apple.com/documentation/appkit/nsevent/1534405-modifierflags "The lower 16 bits of the modifier flags are reserved for device-dependent bits." and for example, on my macOS machine without pressing any modifier keys the event modifier flags contain a non-zero value and therefore cannot be directly compared to the command flags.

This PR:

- fixes Package.swift to open in Xcode and adds macOS platform
- fixes the key event modifiers matching
- adds precedence to matching key commands (Commands with more modifier keys are matched before commands with less)
- adds unit tests for the said changes

Additionally, the code in `FireflyTextView.keyDown(with:)` used to send the event two times - I removed the extra call to `super`.