### PR TITLE
General improvements

### DIFF
--- a/Sources/Extensions/String+NSRange.swift
+++ b/Sources/Extensions/String+NSRange.swift
@@ -11,4 +11,9 @@ extension String {
     func nsRange(fromRange range: Range<Index>) -> NSRange {
         return NSRange(range, in: self)
     }
+    init<T: StringProtocol>(fromRange range: NSRange, in fullString: T) {
+        let start: String.Index = fullString.index(fullString.startIndex, offsetBy: range.location)
+        let end: String.Index = fullString.index(start, offsetBy: range.length)
+        self = String(fullString[start..<end])
+    }
 }

--- a/Sources/Highlighter/Data/Languages.swift
+++ b/Sources/Highlighter/Data/Languages.swift
@@ -7,13 +7,22 @@
 
 import Foundation
 //TODO: if( is matched as a function not a keyword. Figure out a system to match if as a keyword not a function
-let languages: [String: [String: Any]] = [
-    "default": [:],
+var languages: [String: [String: Any]] = [
+    "default": defaultLanguage,
     "jelly": jellyLanguage,
     "swift": swiftLanguage
 ]
+public var fireflyLanguages: [String: [String: Any]] {
+    get {
+        languages
+    }
+    set {
+        languages = newValue
+    }
+}
 
 let defaultLanguage: [String: Any] = [
+    "display_name": "Generic",
     "string": [
         "regex": #"(?<!\\)".*?(?<!\\)""#,
         "group": 0,
@@ -45,6 +54,7 @@ let defaultLanguage: [String: Any] = [
 ]
 
 let jellyLanguage: [String: Any] = [
+    "display_name": "Jelly",
     "function": [
         "regex": "([a-zA-Z_0-9\"\\[\\]\\+-]+)\\(.*?\\)",//\\. -Removed
         "group": 1,
@@ -97,6 +107,7 @@ let jellyLanguage: [String: Any] = [
 ]
 
 let swiftLanguage: [String: Any] = [
+    "display_name": "Swift",
     "identifier": [
         "regex": "(\\.[A-Za-z_]+\\w*)|((NS|UI)[A-Z][a-zA-Z]+)|((println|print)(?=\\())|(Any|Array|AutoreleasingUnsafePointer|BidirectionalReverseView|Bit|Bool|CFunctionPointer|COpaquePointer|CVaListPointer|Character|CollectionOfOne|ConstUnsafePointer|ContiguousArray|Data|Dictionary|DictionaryGenerator|DictionaryIndex|Double|EmptyCollection|EmptyGenerator|EnumerateGenerator|FilterCollectionView|FilterCollectionViewIndex|FilterGenerator|FilterSequenceView|Float|Float80|FloatingPointClassification|GeneratorOf|GeneratorOfOne|GeneratorSequence|HeapBuffer|HeapBuffer|HeapBufferStorage|HeapBufferStorageBase|ImplicitlyUnwrappedOptional|IndexingGenerator|Int|Int16|Int32|Int64|Int8|IntEncoder|LazyBidirectionalCollection|LazyForwardCollection|LazyRandomAccessCollection|LazySequence|Less|MapCollectionView|MapSequenceGenerator|MapSequenceView|MirrorDisposition|ObjectIdentifier|OnHeap|Optional|PermutationGenerator|QuickLookObject|RandomAccessReverseView|Range|RangeGenerator|RawByte|Repeat|ReverseBidirectionalIndex|Printable|ReverseRandomAccessIndex|SequenceOf|SinkOf|Slice|StaticString|StrideThrough|StrideThroughGenerator|StrideTo|StrideToGenerator|String|Index|UTF8View|Index|UnicodeScalarView|IndexType|GeneratorType|UTF16View|UInt|UInt16|UInt32|UInt64|UInt8|UTF16|UTF32|UTF8|UnicodeDecodingResult|UnicodeScalar|Unmanaged|UnsafeArray|UnsafeArrayGenerator|UnsafeMutableArray|UnsafePointer|VaListBuilder|Header|Zip2|ZipGenerator2)",
         "group": 0,

--- a/Sources/Highlighter/Data/Themes.swift
+++ b/Sources/Highlighter/Data/Themes.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-let themes: [String: [String: Any]] = [
+var themes: [String: [String: Any]] = [
     //https://github.com/hdoria/xcode-themes
     "Basic": [
         "default": "#000000",
@@ -1193,3 +1193,12 @@ let themes: [String: [String: Any]] = [
     ],
 
 ]
+
+public var fireflyThemes: [String: [String: Any]] {
+    get {
+        themes
+    }
+    set {
+        themes = newValue
+    }
+}

--- a/Sources/Highlighter/Syntax/Syntax.swift
+++ b/Sources/Highlighter/Syntax/Syntax.swift
@@ -46,17 +46,22 @@ public class Syntax {
     /// Changes the current language & updates the definitions
     /// - Parameter name: Name of the language
     func setLanguage(to name: String) {
+        // clear previous definitions
+        definitions = []
+        
+        // install language definitions
         if let language = languages[name.lowercased()] {
             for item in language {
                 let type = item.key
-                let dict: [String: Any] = item.value as! [String : Any]
-                let regex: String = dict["regex"] as? String ?? ""
-                let group: Int = dict["group"] as? Int ?? 0
-                let relevance: Int = dict["relevance"] as? Int ?? 0
-                let options: [NSRegularExpression.Options] = dict["options"] as? [NSRegularExpression.Options] ?? []
-                let multi: Bool = dict["multiline"] as? Bool ?? false
+                if let dict: [String: Any] = item.value as? [String : Any] {
+                    let regex: String = dict["regex"] as? String ?? ""
+                    let group: Int = dict["group"] as? Int ?? 0
+                    let relevance: Int = dict["relevance"] as? Int ?? 0
+                    let options: [NSRegularExpression.Options] = dict["options"] as? [NSRegularExpression.Options] ?? []
+                    let multi: Bool = dict["multiline"] as? Bool ?? false
 
-                definitions.append(Definition(type: type, regex: regex, group: group, relevance: relevance, matches: options, multiLine: multi))
+                    definitions.append(Definition(type: type, regex: regex, group: group, relevance: relevance, matches: options, multiLine: multi))
+                }
             }
         }
         var editorPlaceholderPattern = "(<#)([^\"\\n]*?)"

--- a/Sources/Views/FireflySyntaxView + TextDelegate.swift
+++ b/Sources/Views/FireflySyntaxView + TextDelegate.swift
@@ -39,8 +39,13 @@ extension FireflySyntaxView: TextViewDelegate {
                 if let token = inside.1 {
                     let fullRange = NSRange(location: 0, length: self.text.utf16.count)
                     if token.range.upperBound < fullRange.upperBound {
+                        #if os(iOS)
+                        let textViewTextStorageString: String = textView.textStorage.string
+                        #else
+                        let textViewTextStorageString: String = textView.textStorage!.string
+                        #endif
                         self.onTextChange(
-                            oldText: String(fromRange: token.range, in: textView.textStorage.string),
+                            oldText: String(fromRange: token.range, in: textViewTextStorageString),
                             location: token.range.location,
                             newText: text
                         )
@@ -77,8 +82,13 @@ extension FireflySyntaxView: TextViewDelegate {
                 // Update on backspace
                 updateGutterNow = true
                 self.textStorage.endEditing()
+                #if os(iOS)
+                let textViewTextStorageString: String = textView.textStorage.string
+                #else
+                let textViewTextStorageString: String = textView.textStorage!.string
+                #endif
                 self.onTextChange(
-                    oldText: String(fromRange: range, in: textView.textStorage.string),
+                    oldText: String(fromRange: range, in: textViewTextStorageString),
                     location: range.location,
                     newText: text
                 )
@@ -108,8 +118,13 @@ extension FireflySyntaxView: TextViewDelegate {
             } else if characterBuffer[1, default: ""] == "\"" && characterBuffer[0, default: ""] != "\""  && characterBuffer[2, default: ""] != "\"" {
                 insertingText += "\""
                 
+                #if os(iOS)
+                let textViewTextStorageString: String = textView.textStorage.string
+                #else
+                let textViewTextStorageString: String = textView.textStorage!.string
+                #endif
                 self.onTextChange(
-                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    oldText: String(fromRange: selectedRange, in: textViewTextStorageString),
                     location: selectedRange.location,
                     newText: insertingText
                 )
@@ -139,8 +154,13 @@ extension FireflySyntaxView: TextViewDelegate {
             } else if characterBuffer[1, default: ""] == "(" && characterBuffer[0, default: ""] != ")" {
                 insertingText += ")"
                 
+                #if os(iOS)
+                let textViewTextStorageString: String = textView.textStorage.string
+                #else
+                let textViewTextStorageString: String = textView.textStorage!.string
+                #endif
                 self.onTextChange(
-                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    oldText: String(fromRange: selectedRange, in: textViewTextStorageString),
                     location: selectedRange.location,
                     newText: insertingText
                 )
@@ -172,8 +192,13 @@ extension FireflySyntaxView: TextViewDelegate {
                 if text == "\n" {
                     insertingText += "\t\(newlineInsert)\n\(newlineInsert)}"
                     
+                    #if os(iOS)
+                    let textViewTextStorageString: String = textView.textStorage.string
+                    #else
+                    let textViewTextStorageString: String = textView.textStorage!.string
+                    #endif
                     self.onTextChange(
-                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        oldText: String(fromRange: selectedRange, in: textViewTextStorageString),
                         location: selectedRange.location,
                         newText: insertingText
                     )
@@ -195,8 +220,13 @@ extension FireflySyntaxView: TextViewDelegate {
                 } else {
                     insertingText += "}"
                     
+                    #if os(iOS)
+                    let textViewTextStorageString: String = textView.textStorage.string
+                    #else
+                    let textViewTextStorageString: String = textView.textStorage!.string
+                    #endif
                     self.onTextChange(
-                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        oldText: String(fromRange: selectedRange, in: textViewTextStorageString),
                         location: selectedRange.location,
                         newText: insertingText
                     )
@@ -237,9 +267,13 @@ extension FireflySyntaxView: TextViewDelegate {
                     lastCompleted = ""
                     insertingText += "\t\(newlineInsert)\n\(newlineInsert)*/"
                     
-                    
+                    #if os(iOS)
+                    let textViewTextStorageString: String = textView.textStorage.string
+                    #else
+                    let textViewTextStorageString: String = textView.textStorage!.string
+                    #endif
                     self.onTextChange(
-                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        oldText: String(fromRange: selectedRange, in: textViewTextStorageString),
                         location: selectedRange.location,
                         newText: insertingText
                     )
@@ -271,8 +305,13 @@ extension FireflySyntaxView: TextViewDelegate {
 //                insertingText.removeFirst()
                 insertingText += newlineInsert
                 
+                #if os(iOS)
+                let textViewTextStorageString: String = textView.textStorage.string
+                #else
+                let textViewTextStorageString: String = textView.textStorage!.string
+                #endif
                 self.onTextChange(
-                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    oldText: String(fromRange: selectedRange, in: textViewTextStorageString),
                     location: selectedRange.location,
                     newText: insertingText
                 )
@@ -308,8 +347,13 @@ extension FireflySyntaxView: TextViewDelegate {
                     lastCompleted = ""
                     insertingText += "*/"
                     
+                    #if os(iOS)
+                    let textViewTextStorageString: String = textView.textStorage.string
+                    #else
+                    let textViewTextStorageString: String = textView.textStorage!.string
+                    #endif
                     self.onTextChange(
-                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        oldText: String(fromRange: selectedRange, in: textViewTextStorageString),
                         location: selectedRange.location,
                         newText: insertingText
                     )
@@ -341,8 +385,13 @@ extension FireflySyntaxView: TextViewDelegate {
         }
         
         self.textStorage.endEditing()
+        #if os(iOS)
+        let textViewTextStorageString: String = textView.textStorage.string
+        #else
+        let textViewTextStorageString: String = textView.textStorage!.string
+        #endif
         self.onTextChange(
-            oldText: String(fromRange: range, in: textView.textStorage.string),
+            oldText: String(fromRange: range, in: textViewTextStorageString),
             location: range.location,
             newText: text
         )

--- a/Sources/Views/FireflySyntaxView + TextDelegate.swift
+++ b/Sources/Views/FireflySyntaxView + TextDelegate.swift
@@ -39,6 +39,12 @@ extension FireflySyntaxView: TextViewDelegate {
                 if let token = inside.1 {
                     let fullRange = NSRange(location: 0, length: self.text.utf16.count)
                     if token.range.upperBound < fullRange.upperBound {
+                        self.notifyWillChange(
+                            oldText: String(fromRange: token.range, in: textView.textStorage.string),
+                            location: token.range.location,
+                            newText: text
+                        )
+                        
                         textStorage.removeAttribute(.font, range: token.range)
                         textStorage.removeAttribute(.foregroundColor, range: token.range)
                         textStorage.removeAttribute(.editorPlaceholder, range: token.range)
@@ -48,11 +54,6 @@ extension FireflySyntaxView: TextViewDelegate {
                         textStorage.cachedTokens.removeAll { (token) -> Bool in return token == token }
 
                         self.textStorage.endEditing()
-                        self.notifyWillChange(
-                            oldText: String(fromRange: token.range, in: textView.textStorage.string),
-                            location: token.range.location,
-                            newText: text
-                        )
                         updateSelectedRange(NSRange(location: token.range.location + text.utf16.count, length: 0))
                         textStorage.highlight(getVisibleRange(), cursorRange: selectedRange)
 
@@ -107,6 +108,12 @@ extension FireflySyntaxView: TextViewDelegate {
             } else if characterBuffer[1, default: ""] == "\"" && characterBuffer[0, default: ""] != "\""  && characterBuffer[2, default: ""] != "\"" {
                 insertingText += "\""
                 
+                self.notifyWillChange(
+                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    location: selectedRange.location,
+                    newText: insertingText
+                )
+                
                 #if canImport(UIKit)
                 textView.textStorage.replaceCharacters(in: selectedRange, with: insertingText)
                 
@@ -121,11 +128,6 @@ extension FireflySyntaxView: TextViewDelegate {
                 textView.setNeedsDisplay(textView.bounds)
                 textView.didChangeText()
                 #endif
-                self.notifyWillChange(
-                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
-                    location: selectedRange.location,
-                    newText: insertingText
-                )
                 
                 shouldHighlightOnChange = false
                 textStorage.editingRange = selectedRange
@@ -136,6 +138,12 @@ extension FireflySyntaxView: TextViewDelegate {
                 return false
             } else if characterBuffer[1, default: ""] == "(" && characterBuffer[0, default: ""] != ")" {
                 insertingText += ")"
+                
+                self.notifyWillChange(
+                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    location: selectedRange.location,
+                    newText: insertingText
+                )
                 
                 #if canImport(UIKit)
                 textView.textStorage.replaceCharacters(in: selectedRange, with: insertingText)
@@ -151,11 +159,6 @@ extension FireflySyntaxView: TextViewDelegate {
                 textView.setNeedsDisplay(textView.bounds)
                 textView.didChangeText()
                 #endif
-                self.notifyWillChange(
-                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
-                    location: selectedRange.location,
-                    newText: insertingText
-                )
                 
                 shouldHighlightOnChange = false
                 textStorage.editingRange = selectedRange
@@ -168,6 +171,13 @@ extension FireflySyntaxView: TextViewDelegate {
                 // Update on new line
                 if text == "\n" {
                     insertingText += "\t\(newlineInsert)\n\(newlineInsert)}"
+                    
+                    self.notifyWillChange(
+                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        location: selectedRange.location,
+                        newText: insertingText
+                    )
+                    
                     #if canImport(UIKit)
                     textView.textStorage.replaceCharacters(in: selectedRange, with: insertingText)
                     
@@ -184,6 +194,13 @@ extension FireflySyntaxView: TextViewDelegate {
                     #endif
                 } else {
                     insertingText += "}"
+                    
+                    self.notifyWillChange(
+                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        location: selectedRange.location,
+                        newText: insertingText
+                    )
+                    
                     #if canImport(UIKit)
                     textView.textStorage.replaceCharacters(in: selectedRange, with: insertingText)
                     
@@ -203,11 +220,6 @@ extension FireflySyntaxView: TextViewDelegate {
                 shouldHighlightOnChange = false
                 textStorage.editingRange = selectedRange
                 self.textStorage.endEditing()
-                self.notifyWillChange(
-                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
-                    location: selectedRange.location,
-                    newText: insertingText
-                )
                 textStorage.highlight(getVisibleRange(), cursorRange: selectedRange)
                 
                 delegate?.didChangeText(tView)
@@ -225,6 +237,12 @@ extension FireflySyntaxView: TextViewDelegate {
                     lastCompleted = ""
                     insertingText += "\t\(newlineInsert)\n\(newlineInsert)*/"
                     
+                    
+                    self.notifyWillChange(
+                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        location: selectedRange.location,
+                        newText: insertingText
+                    )
                     #if canImport(UIKit)
                     textView.textStorage.replaceCharacters(in: selectedRange, with: insertingText)
                     
@@ -239,11 +257,6 @@ extension FireflySyntaxView: TextViewDelegate {
                     textView.setNeedsDisplay(textView.bounds)
                     textView.didChangeText()
                     #endif
-                    self.notifyWillChange(
-                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
-                        location: selectedRange.location,
-                        newText: insertingText
-                    )
                     
                     shouldHighlightOnChange = false
                     textStorage.editingRange = selectedRange
@@ -257,7 +270,12 @@ extension FireflySyntaxView: TextViewDelegate {
             } else {
 //                insertingText.removeFirst()
                 insertingText += newlineInsert
-
+                
+                self.notifyWillChange(
+                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    location: selectedRange.location,
+                    newText: insertingText
+                )
                 #if canImport(UIKit)
                 textView.textStorage.replaceCharacters(in: selectedRange, with: insertingText)
                 
@@ -273,11 +291,6 @@ extension FireflySyntaxView: TextViewDelegate {
                 textView.didChangeText()
                 
                 #endif
-                self.notifyWillChange(
-                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
-                    location: selectedRange.location,
-                    newText: insertingText
-                )
                 
                 updateGutterWidth()
                 shouldHighlightOnChange = false
@@ -295,6 +308,11 @@ extension FireflySyntaxView: TextViewDelegate {
                     lastCompleted = ""
                     insertingText += "*/"
                     
+                    self.notifyWillChange(
+                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        location: selectedRange.location,
+                        newText: insertingText
+                    )
                     #if canImport(UIKit)
                     textView.textStorage.replaceCharacters(in: selectedRange, with: insertingText)
                     
@@ -309,11 +327,6 @@ extension FireflySyntaxView: TextViewDelegate {
                     textView.setNeedsDisplay(textView.bounds)
                     textView.didChangeText()
                     #endif
-                    self.notifyWillChange(
-                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
-                        location: selectedRange.location,
-                        newText: insertingText
-                    )
                     
                     shouldHighlightOnChange = false
                     textStorage.editingRange = selectedRange

--- a/Sources/Views/FireflySyntaxView + TextDelegate.swift
+++ b/Sources/Views/FireflySyntaxView + TextDelegate.swift
@@ -48,6 +48,11 @@ extension FireflySyntaxView: TextViewDelegate {
                         textStorage.cachedTokens.removeAll { (token) -> Bool in return token == token }
 
                         self.textStorage.endEditing()
+                        self.notifyWillChange(
+                            oldText: String(fromRange: token.range, in: textView.textStorage.string),
+                            location: token.range.location,
+                            newText: text
+                        )
                         updateSelectedRange(NSRange(location: token.range.location + text.utf16.count, length: 0))
                         textStorage.highlight(getVisibleRange(), cursorRange: selectedRange)
 
@@ -71,6 +76,11 @@ extension FireflySyntaxView: TextViewDelegate {
                 // Update on backspace
                 updateGutterNow = true
                 self.textStorage.endEditing()
+                self.notifyWillChange(
+                    oldText: String(fromRange: range, in: textView.textStorage.string),
+                    location: range.location,
+                    newText: text
+                )
                 return true
             }
         }
@@ -111,6 +121,11 @@ extension FireflySyntaxView: TextViewDelegate {
                 textView.setNeedsDisplay(textView.bounds)
                 textView.didChangeText()
                 #endif
+                self.notifyWillChange(
+                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    location: selectedRange.location,
+                    newText: insertingText
+                )
                 
                 shouldHighlightOnChange = false
                 textStorage.editingRange = selectedRange
@@ -136,6 +151,11 @@ extension FireflySyntaxView: TextViewDelegate {
                 textView.setNeedsDisplay(textView.bounds)
                 textView.didChangeText()
                 #endif
+                self.notifyWillChange(
+                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    location: selectedRange.location,
+                    newText: insertingText
+                )
                 
                 shouldHighlightOnChange = false
                 textStorage.editingRange = selectedRange
@@ -183,6 +203,11 @@ extension FireflySyntaxView: TextViewDelegate {
                 shouldHighlightOnChange = false
                 textStorage.editingRange = selectedRange
                 self.textStorage.endEditing()
+                self.notifyWillChange(
+                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    location: selectedRange.location,
+                    newText: insertingText
+                )
                 textStorage.highlight(getVisibleRange(), cursorRange: selectedRange)
                 
                 delegate?.didChangeText(tView)
@@ -214,6 +239,11 @@ extension FireflySyntaxView: TextViewDelegate {
                     textView.setNeedsDisplay(textView.bounds)
                     textView.didChangeText()
                     #endif
+                    self.notifyWillChange(
+                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        location: selectedRange.location,
+                        newText: insertingText
+                    )
                     
                     shouldHighlightOnChange = false
                     textStorage.editingRange = selectedRange
@@ -243,6 +273,11 @@ extension FireflySyntaxView: TextViewDelegate {
                 textView.didChangeText()
                 
                 #endif
+                self.notifyWillChange(
+                    oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                    location: selectedRange.location,
+                    newText: insertingText
+                )
                 
                 updateGutterWidth()
                 shouldHighlightOnChange = false
@@ -274,6 +309,11 @@ extension FireflySyntaxView: TextViewDelegate {
                     textView.setNeedsDisplay(textView.bounds)
                     textView.didChangeText()
                     #endif
+                    self.notifyWillChange(
+                        oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
+                        location: selectedRange.location,
+                        newText: insertingText
+                    )
                     
                     shouldHighlightOnChange = false
                     textStorage.editingRange = selectedRange
@@ -288,6 +328,11 @@ extension FireflySyntaxView: TextViewDelegate {
         }
         
         self.textStorage.endEditing()
+        self.notifyWillChange(
+            oldText: String(fromRange: range, in: textView.textStorage.string),
+            location: range.location,
+            newText: text
+        )
         return true
     }
     

--- a/Sources/Views/FireflySyntaxView + TextDelegate.swift
+++ b/Sources/Views/FireflySyntaxView + TextDelegate.swift
@@ -39,7 +39,7 @@ extension FireflySyntaxView: TextViewDelegate {
                 if let token = inside.1 {
                     let fullRange = NSRange(location: 0, length: self.text.utf16.count)
                     if token.range.upperBound < fullRange.upperBound {
-                        self.notifyWillChange(
+                        self.onTextChange(
                             oldText: String(fromRange: token.range, in: textView.textStorage.string),
                             location: token.range.location,
                             newText: text
@@ -77,7 +77,7 @@ extension FireflySyntaxView: TextViewDelegate {
                 // Update on backspace
                 updateGutterNow = true
                 self.textStorage.endEditing()
-                self.notifyWillChange(
+                self.onTextChange(
                     oldText: String(fromRange: range, in: textView.textStorage.string),
                     location: range.location,
                     newText: text
@@ -108,7 +108,7 @@ extension FireflySyntaxView: TextViewDelegate {
             } else if characterBuffer[1, default: ""] == "\"" && characterBuffer[0, default: ""] != "\""  && characterBuffer[2, default: ""] != "\"" {
                 insertingText += "\""
                 
-                self.notifyWillChange(
+                self.onTextChange(
                     oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
                     location: selectedRange.location,
                     newText: insertingText
@@ -139,7 +139,7 @@ extension FireflySyntaxView: TextViewDelegate {
             } else if characterBuffer[1, default: ""] == "(" && characterBuffer[0, default: ""] != ")" {
                 insertingText += ")"
                 
-                self.notifyWillChange(
+                self.onTextChange(
                     oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
                     location: selectedRange.location,
                     newText: insertingText
@@ -172,7 +172,7 @@ extension FireflySyntaxView: TextViewDelegate {
                 if text == "\n" {
                     insertingText += "\t\(newlineInsert)\n\(newlineInsert)}"
                     
-                    self.notifyWillChange(
+                    self.onTextChange(
                         oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
                         location: selectedRange.location,
                         newText: insertingText
@@ -195,7 +195,7 @@ extension FireflySyntaxView: TextViewDelegate {
                 } else {
                     insertingText += "}"
                     
-                    self.notifyWillChange(
+                    self.onTextChange(
                         oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
                         location: selectedRange.location,
                         newText: insertingText
@@ -238,7 +238,7 @@ extension FireflySyntaxView: TextViewDelegate {
                     insertingText += "\t\(newlineInsert)\n\(newlineInsert)*/"
                     
                     
-                    self.notifyWillChange(
+                    self.onTextChange(
                         oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
                         location: selectedRange.location,
                         newText: insertingText
@@ -271,7 +271,7 @@ extension FireflySyntaxView: TextViewDelegate {
 //                insertingText.removeFirst()
                 insertingText += newlineInsert
                 
-                self.notifyWillChange(
+                self.onTextChange(
                     oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
                     location: selectedRange.location,
                     newText: insertingText
@@ -308,7 +308,7 @@ extension FireflySyntaxView: TextViewDelegate {
                     lastCompleted = ""
                     insertingText += "*/"
                     
-                    self.notifyWillChange(
+                    self.onTextChange(
                         oldText: String(fromRange: selectedRange, in: textView.textStorage.string),
                         location: selectedRange.location,
                         newText: insertingText
@@ -341,7 +341,7 @@ extension FireflySyntaxView: TextViewDelegate {
         }
         
         self.textStorage.endEditing()
-        self.notifyWillChange(
+        self.onTextChange(
             oldText: String(fromRange: range, in: textView.textStorage.string),
             location: range.location,
             newText: text
@@ -399,6 +399,7 @@ extension FireflySyntaxView: TextViewDelegate {
     public func textViewDidChangeSelection(_ textView: UITextView) {
         updateCursorPosition()
         delegate?.didChangeSelectedRange(self.textView, selectedRange: self.textView.selectedRange)
+        self.onSelectionChange(selectionRange: self.textView.selectedRange)
     }
     
     /// Override the key commands recognized by the view
@@ -423,6 +424,7 @@ extension FireflySyntaxView: TextViewDelegate {
     public func textViewDidChangeSelection(_ notification: Notification) {
         updateCursorPosition()
         delegate?.didChangeSelectedRange(textView, selectedRange: textView.selectedRange())
+        self.onSelectionChange(selectionRange: textView.selectedRange())
     }
     
     /// Handles highlighting the correct amount of the view when text changes
@@ -486,6 +488,7 @@ extension FireflySyntaxView {
             #elseif canImport(AppKit)
             textView.setSelectedRange(range)
             #endif
+            self.onSelectionChange(selectionRange: range)
         }
     }
     

--- a/Sources/Views/FireflySyntaxView.swift
+++ b/Sources/Views/FireflySyntaxView.swift
@@ -216,6 +216,7 @@ public class FireflySyntaxView: FireflyView {
         textView.autocorrectionType = .no
         textView.spellCheckingType = .no
         textView.smartQuotesType = .no
+        textView.smartDashesType = .no
         textView.smartInsertDeleteType = .no
         
         if self.textStorage.syntax.theme.style == .dark {

--- a/Sources/Views/FireflySyntaxView.swift
+++ b/Sources/Views/FireflySyntaxView.swift
@@ -14,7 +14,10 @@ import UIKit
 public class FireflySyntaxView: FireflyView {
     
     /// A closure called whenever the text contents is modified.
-    private var notifyWillChangeClosure: ((_ oldText: String, _ location: Int, _ newText: String) -> Void)? = nil
+    private var onTextChangeClosure: ((_ oldText: String, _ location: Int, _ newText: String) -> Void)? = nil
+    
+    /// A closure called whenever the text selection changes.
+    private var onSelectionChangeClosure: ((_ selectionRange: NSRange) -> Void)?
     
     /// The highlighting language
     @IBInspectable
@@ -40,7 +43,7 @@ public class FireflySyntaxView: FireflyView {
             if dynamicGutterWidth {
                 updateGutterWidth()
             }
-            textView.selectedRange = NSRange(location: 0, length: 0)
+            self.updateSelectedRange(NSRange(location: 0, length: 0))
         }
     }
     
@@ -451,11 +454,16 @@ public class FireflySyntaxView: FireflyView {
 
     #endif
     
-
-    /// Sets the closure to be called whenever the text contents is modified/
-    /// - Parameter notifyWillChange: The closure.
-    public func setNotifyWillChange(_ notifyWillChange: ((_ oldText: String, _ location: Int, _ newText: String) -> Void)?) {
-        self.notifyWillChangeClosure = notifyWillChange
+    /// Sets the closure to be called whenever the text contents is modified
+    /// - Parameter onTextChange: The closure.
+    public func setOnTextChange(_ onTextChange: ((_ oldText: String, _ location: Int, _ newText: String) -> Void)?) {
+        self.onTextChangeClosure = onTextChange
+    }
+    
+    /// Sets the closure to be called whenever the text selection changes
+    /// - Parameter onSelectionChange: The closure.
+    public func setOnSelectionChange(_ onSelectionChange: ((_ selectionRange: NSRange) -> Void)?) {
+        self.onSelectionChangeClosure = onSelectionChange
     }
     
     /// Sets the theme of the view. Supply with a theme name
@@ -712,14 +720,25 @@ extension FireflySyntaxView {
         #endif
     }
     
-    /// Sends out notification of a section of text changing. Note that because calculating `oldText` is usually an extra step required, the param is
+    /// Sends out notification of a section of text changing. Note that because calculating `oldText` is usually an extra step, the param is
     /// marked as an auto-closure so that the body is only calcuated in the case that there is a `notifyWillChangeClosure` to actually notify.
     /// - Parameter oldText: Contents of the section before the change.
     /// - Parameter location: The index of the change.
     /// - Parameter newText: Contents of the section after the change..
-    internal func notifyWillChange(oldText: @autoclosure () -> String, location: Int, newText: String) {
-        if let notifyWillChangeClosure = self.notifyWillChangeClosure {
-            notifyWillChangeClosure(oldText(), location, newText)
+    internal func onTextChange(oldText: @autoclosure () -> String, location: Int, newText: String) {
+        if let onTextChangeClosure = self.onTextChangeClosure {
+            onTextChangeClosure(oldText(), location, newText)
+        }
+    }
+    
+    /// Sends out notification that the text selection range has changed. Note that because calculating `selectionRange` is usually an extra step,
+    /// the param is marked as an auto-closure so that the body is only calcuated when needed.
+    /// - Parameter oldText: Contents of the section before the change.
+    /// - Parameter location: The index of the change.
+    /// - Parameter newText: Contents of the section after the change..
+    internal func onSelectionChange(selectionRange: @autoclosure () -> NSRange) {
+        if let onSelectionChangeClosure = self.onSelectionChangeClosure {
+            onSelectionChangeClosure(selectionRange())
         }
     }
 }

--- a/Tests/FireflyTests/FireflyTextViewTests.swift
+++ b/Tests/FireflyTests/FireflyTextViewTests.swift
@@ -9,9 +9,11 @@ import XCTest
 
 class FireflyTextViewTests: XCTestCase {
 
+    #if canImport(AppKit)
 	private func keyDownEvent(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> NSEvent? {
 		return NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: modifiers, timestamp: Date().timeIntervalSinceReferenceDate, windowNumber: 0, context: nil, characters: "", charactersIgnoringModifiers: "", isARepeat: false, keyCode: keyCode)
 	}
+    #endif
 
 	func testKeyCommandModifiersMatching() throws {
 	#if canImport(AppKit)


### PR DESCRIPTION
Here's a list of what I've changed on my fork
 - a bug fix for when you change themes on an already open editor
 - a few properties made `public`
 - a new `onTextChange` listener which provides details about what section of text changed
 - smart dashes disabled
 - a `display_name` field is added to the languages spec
 - a new `onSelectionChange` listener. I think something like this already existed noticed after I implemented it. Maybe `onSelectionChangeClosure` should be removed before merge?